### PR TITLE
Refactor this function to reduce its Cognitive Complexity from 18 to …

### DIFF
--- a/homeassistant/components/homekit/__init__.py
+++ b/homeassistant/components/homekit/__init__.py
@@ -841,44 +841,68 @@ class HomeKit:
         return None
 
     async def async_configure_accessories(self) -> list[State]:
-        """Configure accessories for the included states."""
-        dev_reg = dr.async_get(self.hass)
-        ent_reg = er.async_get(self.hass)
-        device_lookup: dict[str, dict[tuple[str, str | None], str]] = {}
-        entity_states: list[State] = []
-        entity_filter = self._filter.get_filter()
-        entries = ent_reg.entities
-        for state in self.hass.states.async_all():
-            entity_id = state.entity_id
-            if not entity_filter(entity_id):
+    """Configure accessories for the included states."""
+    dev_reg = dr.async_get(self.hass)
+    ent_reg = er.async_get(self.hass)
+    device_lookup: dict[str, dict[tuple[str, str | None], str]] = {}
+    entity_states: list[State] = []
+    entity_filter = self._filter.get_filter()
+
+    for state in self.hass.states.async_all():
+        entity_id = state.entity_id
+        if not entity_filter(entity_id):
+            continue
+
+        if ent_reg_ent := ent_reg.async_get(entity_id):
+            if self._should_skip_entity(ent_reg_ent, entity_id):
                 continue
 
-            if ent_reg_ent := ent_reg.async_get(entity_id):
-                if (
-                    ent_reg_ent.entity_category is not None
-                    or ent_reg_ent.hidden_by is not None
-                ) and not self._filter.explicitly_included(entity_id):
-                    continue
+            await self._handle_entity(ent_reg_ent, dev_reg, entity_id, device_lookup, state)
 
-                await self._async_set_device_info_attributes(
-                    ent_reg_ent, dev_reg, entity_id
-                )
-                if device_id := ent_reg_ent.device_id:
-                    if device_id not in device_lookup:
-                        device_lookup[device_id] = {
-                            (
-                                entry.domain,
-                                entry.device_class or entry.original_device_class,
-                            ): entry.entity_id
-                            for entry in entries.get_entries_for_device_id(device_id)
-                        }
-                    self._async_configure_linked_sensors(
-                        ent_reg_ent, device_lookup[device_id], state
-                    )
+        entity_states.append(state)
 
-            entity_states.append(state)
+    return entity_states
 
-        return entity_states
+
+def _should_skip_entity(self, ent_reg_ent, entity_id: str) -> bool:
+    """Determine if an entity should be skipped."""
+    return (
+        (ent_reg_ent.entity_category is not None or ent_reg_ent.hidden_by is not None)
+        and not self._filter.explicitly_included(entity_id)
+    )
+
+
+async def _handle_entity(
+    self,
+    ent_reg_ent,
+    dev_reg,
+    entity_id: str,
+    device_lookup: dict[str, dict[tuple[str, str | None], str]],
+    state: State,
+) -> None:
+    """Handle the configuration of a single entity."""
+    await self._async_set_device_info_attributes(ent_reg_ent, dev_reg, entity_id)
+    if device_id := ent_reg_ent.device_id:
+        if device_id not in device_lookup:
+            device_lookup[device_id] = self._create_device_lookup(device_id, ent_reg)
+        self._async_configure_linked_sensors(
+            ent_reg_ent, device_lookup[device_id], state
+        )
+
+
+def _create_device_lookup(
+    self, device_id: str, ent_reg
+) -> dict[tuple[str, str | None], str]:
+    """Create a device lookup for a given device ID."""
+    entries = ent_reg.entities
+    return {
+        (
+            entry.domain,
+            entry.device_class or entry.original_device_class,
+        ): entry.entity_id
+        for entry in entries.get_entries_for_device_id(device_id)
+    }
+
 
     async def async_start(self, *args: Any) -> None:
         """Load storage and start."""


### PR DESCRIPTION
…the 15 allowed: Update __init__.py

This refactoring simplifies the main function while keeping its functionality, thus reducing its cognitive complexity as a result.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
