### PR TITLE
Refactor this function to reduce its Cognitive Complexity from 24 to …

### DIFF
--- a/homeassistant/components/homekit/accessories.py
+++ b/homeassistant/components/homekit/accessories.py
@@ -286,141 +286,164 @@ class HomeAccessory(Accessory):  # type: ignore[misc]
     driver: HomeDriver
 
     def __init__(
-        self,
-        hass: HomeAssistant,
-        driver: HomeDriver,
-        name: str,
-        entity_id: str,
-        aid: int,
-        config: dict[str, Any],
-        *args: Any,
-        category: int = CATEGORY_OTHER,
-        device_id: str | None = None,
-        **kwargs: Any,
-    ) -> None:
-        """Initialize a Accessory object."""
-        super().__init__(
-            driver=driver,
-            display_name=cleanup_name_for_homekit(name),
-            aid=aid,
-            iid_manager=HomeIIDManager(driver.iid_storage),
-            *args,  # noqa: B026
-            **kwargs,
-        )
-        self._reload_on_change_attrs = list(RELOAD_ON_CHANGE_ATTRS)
-        self.config = config or {}
-        if device_id:
-            self.device_id: str | None = device_id
-            serial_number = device_id
-            domain = None
-        else:
-            self.device_id = None
-            serial_number = entity_id
-            domain = split_entity_id(entity_id)[0].replace("_", " ")
+    self,
+    hass: HomeAssistant,
+    driver: HomeDriver,
+    name: str,
+    entity_id: str,
+    aid: int,
+    config: dict[str, Any],
+    *args: Any,
+    category: int = CATEGORY_OTHER,
+    device_id: str | None = None,
+    **kwargs: Any,
+) -> None:
+    """Initialize an Accessory object."""
+    super().__init__(
+        driver=driver,
+        display_name=cleanup_name_for_homekit(name),
+        aid=aid,
+        iid_manager=HomeIIDManager(driver.iid_storage),
+        *args,  # noqa: B026
+        **kwargs,
+    )
+    self.hass = hass
+    self.config = config or {}
+    self.entity_id = entity_id
+    self.category = category
+    self.device_id = device_id
+    self._subscriptions: list[CALLBACK_TYPE] = []
 
-        if self.config.get(ATTR_MANUFACTURER) is not None:
-            manufacturer = str(self.config[ATTR_MANUFACTURER])
-        elif self.config.get(ATTR_INTEGRATION) is not None:
-            manufacturer = self.config[ATTR_INTEGRATION].replace("_", " ").title()
-        elif domain:
-            manufacturer = f"{MANUFACTURER} {domain}".title()
-        else:
-            manufacturer = MANUFACTURER
-        if self.config.get(ATTR_MODEL) is not None:
-            model = str(self.config[ATTR_MODEL])
-        elif domain:
-            model = domain.title()
-        else:
-            model = MANUFACTURER
-        sw_version = None
-        if self.config.get(ATTR_SW_VERSION) is not None:
-            sw_version = format_version(self.config[ATTR_SW_VERSION])
-        if sw_version is None:
-            sw_version = format_version(__version__)
-            assert sw_version is not None
-        hw_version = None
-        if self.config.get(ATTR_HW_VERSION) is not None:
-            hw_version = format_version(self.config[ATTR_HW_VERSION])
+    self._reload_on_change_attrs = list(RELOAD_ON_CHANGE_ATTRS)
 
-        self.set_info_service(
-            manufacturer=manufacturer[:MAX_MANUFACTURER_LENGTH],
-            model=model[:MAX_MODEL_LENGTH],
-            serial_number=serial_number[:MAX_SERIAL_LENGTH],
-            firmware_revision=sw_version[:MAX_VERSION_LENGTH],
-        )
-        if hw_version:
-            serv_info = self.get_service(SERV_ACCESSORY_INFO)
-            char = self.driver.loader.get_char(CHAR_HARDWARE_REVISION)
-            serv_info.add_characteristic(char)
-            serv_info.configure_char(
-                CHAR_HARDWARE_REVISION, value=hw_version[:MAX_VERSION_LENGTH]
+    serial_number, domain = self._initialize_device_metadata(entity_id, device_id)
+    manufacturer, model, sw_version, hw_version = self._initialize_info_attributes(domain)
+
+    self.set_info_service(
+        manufacturer=manufacturer[:MAX_MANUFACTURER_LENGTH],
+        model=model[:MAX_MODEL_LENGTH],
+        serial_number=serial_number[:MAX_SERIAL_LENGTH],
+        firmware_revision=sw_version[:MAX_VERSION_LENGTH],
+    )
+
+    if hw_version:
+        self._add_hardware_version(hw_version)
+
+    if not device_id:
+        self._initialize_battery_service()
+
+def _initialize_device_metadata(self, entity_id: str, device_id: str | None) -> tuple[str, str | None]:
+    """Initialize device metadata."""
+    if device_id:
+        serial_number = device_id
+        domain = None
+    else:
+        serial_number = entity_id
+        domain = split_entity_id(entity_id)[0].replace("_", " ")
+
+    return serial_number, domain
+
+def _initialize_info_attributes(self, domain: str | None) -> tuple[str, str, str, str | None]:
+    """Initialize manufacturer, model, software, and hardware version attributes."""
+    manufacturer = self._get_manufacturer(domain)
+    model = self._get_model(domain)
+    sw_version = self._get_software_version()
+    hw_version = self._get_hardware_version()
+
+    return manufacturer, model, sw_version, hw_version
+
+def _get_manufacturer(self, domain: str | None) -> str:
+    """Determine manufacturer."""
+    if self.config.get(ATTR_MANUFACTURER):
+        return str(self.config[ATTR_MANUFACTURER])
+    if self.config.get(ATTR_INTEGRATION):
+        return self.config[ATTR_INTEGRATION].replace("_", " ").title()
+    if domain:
+        return f"{MANUFACTURER} {domain}".title()
+    return MANUFACTURER
+
+def _get_model(self, domain: str | None) -> str:
+    """Determine model."""
+    if self.config.get(ATTR_MODEL):
+        return str(self.config[ATTR_MODEL])
+    if domain:
+        return domain.title()
+    return MANUFACTURER
+
+def _get_software_version(self) -> str:
+    """Get software version."""
+    sw_version = self.config.get(ATTR_SW_VERSION)
+    if sw_version:
+        return format_version(sw_version)
+    return format_version(__version__)
+
+def _get_hardware_version(self) -> str | None:
+    """Get hardware version."""
+    hw_version = self.config.get(ATTR_HW_VERSION)
+    if hw_version:
+        return format_version(hw_version)
+    return None
+
+def _add_hardware_version(self, hw_version: str) -> None:
+    """Add hardware version characteristic."""
+    serv_info = self.get_service(SERV_ACCESSORY_INFO)
+    char = self.driver.loader.get_char(CHAR_HARDWARE_REVISION)
+    serv_info.add_characteristic(char)
+    serv_info.configure_char(
+        CHAR_HARDWARE_REVISION, value=hw_version[:MAX_VERSION_LENGTH]
+    )
+    char.broker = self
+    self.iid_manager.assign(char)
+
+def _initialize_battery_service(self) -> None:
+    """Initialize battery service if available."""
+    state = self.hass.states.get(self.entity_id)
+    self._update_available_from_state(state)
+
+    if not state:
+        return
+
+    entity_attributes = state.attributes
+    battery_found = entity_attributes.get(ATTR_BATTERY_LEVEL)
+
+    if self.linked_battery_sensor:
+        state = self.hass.states.get(self.linked_battery_sensor)
+        if state:
+            battery_found = state.state
+        else:
+            _LOGGER.warning(
+                "%s: Battery sensor state missing: %s",
+                self.entity_id,
+                self.linked_battery_sensor,
             )
-            char.broker = self
-            self.iid_manager.assign(char)
+            self.linked_battery_sensor = None
 
-        self.category = category
-        self.entity_id = entity_id
-        self.hass = hass
-        self._subscriptions: list[CALLBACK_TYPE] = []
+    if not battery_found:
+        return
 
-        if device_id:
-            return
+    _LOGGER.debug("%s: Found battery level", self.entity_id)
 
-        self._char_battery = None
-        self._char_charging = None
-        self._char_low_battery = None
-        self.linked_battery_sensor = self.config.get(CONF_LINKED_BATTERY_SENSOR)
-        self.linked_battery_charging_sensor = self.config.get(
-            CONF_LINKED_BATTERY_CHARGING_SENSOR
-        )
-        self.low_battery_threshold = self.config.get(
-            CONF_LOW_BATTERY_THRESHOLD, DEFAULT_LOW_BATTERY_THRESHOLD
-        )
+    if self.linked_battery_charging_sensor:
+        state = self.hass.states.get(self.linked_battery_charging_sensor)
+        if not state:
+            _LOGGER.warning(
+                "%s: Battery charging binary_sensor state missing: %s",
+                self.entity_id,
+                self.linked_battery_charging_sensor,
+            )
+            self.linked_battery_charging_sensor = None
+        else:
+            _LOGGER.debug("%s: Found battery charging", self.entity_id)
 
-        """Add battery service if available"""
-        state = self.hass.states.get(self.entity_id)
-        self._update_available_from_state(state)
-        assert state is not None
-        entity_attributes = state.attributes
-        battery_found = entity_attributes.get(ATTR_BATTERY_LEVEL)
+    serv_battery = self.add_preload_service(SERV_BATTERY_SERVICE)
+    self._char_battery = serv_battery.configure_char(CHAR_BATTERY_LEVEL, value=0)
+    self._char_charging = serv_battery.configure_char(
+        CHAR_CHARGING_STATE, value=HK_NOT_CHARGABLE
+    )
+    self._char_low_battery = serv_battery.configure_char(
+        CHAR_STATUS_LOW_BATTERY, value=0
+    )
 
-        if self.linked_battery_sensor:
-            state = self.hass.states.get(self.linked_battery_sensor)
-            if state is not None:
-                battery_found = state.state
-            else:
-                _LOGGER.warning(
-                    "%s: Battery sensor state missing: %s",
-                    self.entity_id,
-                    self.linked_battery_sensor,
-                )
-                self.linked_battery_sensor = None
-
-        if not battery_found:
-            return
-
-        _LOGGER.debug("%s: Found battery level", self.entity_id)
-
-        if self.linked_battery_charging_sensor:
-            state = self.hass.states.get(self.linked_battery_charging_sensor)
-            if state is None:
-                self.linked_battery_charging_sensor = None
-                _LOGGER.warning(
-                    "%s: Battery charging binary_sensor state missing: %s",
-                    self.entity_id,
-                    self.linked_battery_charging_sensor,
-                )
-            else:
-                _LOGGER.debug("%s: Found battery charging", self.entity_id)
-
-        serv_battery = self.add_preload_service(SERV_BATTERY_SERVICE)
-        self._char_battery = serv_battery.configure_char(CHAR_BATTERY_LEVEL, value=0)
-        self._char_charging = serv_battery.configure_char(
-            CHAR_CHARGING_STATE, value=HK_NOT_CHARGABLE
-        )
-        self._char_low_battery = serv_battery.configure_char(
-            CHAR_STATUS_LOW_BATTERY, value=0
-        )
 
     def _update_available_from_state(self, new_state: State | None) -> None:
         """Update the available property based on the state."""


### PR DESCRIPTION
…the 15 allowed: Update accessories.py

Added private methods for specific tasks to make the __init__ cleaner and less complex.

<!--
  You are amazing! Thanks for contributing to our project!
  Please, DO NOT DELETE ANY TEXT from this template! (unless instructed).
-->
## Breaking change
<!--
  If your PR contains a breaking change for existing users, it is important
  to tell them what breaks, how to make it work again and why we did this.
  This piece of text is published with the release notes, so it helps if you
  write it towards our users, not us.
  Note: Remove this section if this PR is NOT a breaking change.
-->


## Proposed change
<!--
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request. If it fixes a bug
  or resolves a feature request, be sure to link to that issue in the
  additional information section.
-->


## Type of change
<!--
  What type of change does your PR introduce to Home Assistant?
  NOTE: Please, check only 1! box!
  If your PR requires multiple boxes to be checked, you'll most likely need to
  split it into multiple PRs. This makes things easier and faster to code review.
-->

- [ ] Dependency upgrade
- [ ] Bugfix (non-breaking change which fixes an issue)
- [ ] New integration (thank you!)
- [ ] New feature (which adds functionality to an existing integration)
- [ ] Deprecation (breaking change to happen in the future)
- [ ] Breaking change (fix/feature causing existing functionality to break)
- [ ] Code quality improvements to existing code or addition of tests

## Additional information
<!--
  Details are important, and help maintainers processing your PR.
  Please be sure to fill out additional details, if applicable.
-->

- This PR fixes or closes issue: fixes #
- This PR is related to issue: 
- Link to documentation pull request: 

## Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. If you're unsure about any of them, don't hesitate to ask.
  We're here to help! This is simply a reminder of what we are going to look
  for before merging your code.
-->

- [ ] The code change is tested and works locally.
- [ ] Local tests pass. **Your PR cannot be merged unless tests pass**
- [ ] There is no commented out code in this PR.
- [ ] I have followed the [development checklist][dev-checklist]
- [ ] I have followed the [perfect PR recommendations][perfect-pr]
- [ ] The code has been formatted using Ruff (`ruff format homeassistant tests`)
- [ ] Tests have been added to verify that the new code works.

If user exposed functionality or configuration variables are added/changed:

- [ ] Documentation added/updated for [www.home-assistant.io][docs-repository]

If the code communicates with devices, web services, or third-party tools:

- [ ] The [manifest file][manifest-docs] has all fields filled out correctly.  
      Updated and included derived files by running: `python3 -m script.hassfest`.
- [ ] New or updated dependencies have been added to `requirements_all.txt`.  
      Updated by running `python3 -m script.gen_requirements_all`.
- [ ] For the updated dependencies - a link to the changelog, or at minimum a diff between library versions is added to the PR description.

<!--
  This project is very active and we have a high turnover of pull requests.

  Unfortunately, the number of incoming pull requests is higher than what our
  reviewers can review and merge so there is a long backlog of pull requests
  waiting for review. You can help here!
  
  By reviewing another pull request, you will help raise the code quality of
  that pull request and the final review will be faster. This way the general
  pace of pull request reviews will go up and your wait time will go down.
  
  When picking a pull request to review, try to choose one that hasn't yet
  been reviewed.

  Thanks for helping out!
-->

To help with the load of incoming pull requests:

- [ ] I have reviewed two other [open pull requests][prs] in this repository.

[prs]: https://github.com/home-assistant/core/pulls?q=is%3Aopen+is%3Apr+-author%3A%40me+-draft%3Atrue+-label%3Awaiting-for-upstream+sort%3Acreated-desc+review%3Anone+-status%3Afailure

<!--
  Thank you for contributing <3

  Below, some useful links you could explore:
-->
[dev-checklist]: https://developers.home-assistant.io/docs/development_checklist/
[manifest-docs]: https://developers.home-assistant.io/docs/creating_integration_manifest/
[quality-scale]: https://developers.home-assistant.io/docs/integration_quality_scale_index/
[docs-repository]: https://github.com/home-assistant/home-assistant.io
[perfect-pr]: https://developers.home-assistant.io/docs/review-process/#creating-the-perfect-pr
